### PR TITLE
Specify encoding of keys and values of urlencoded body - fix for non-ascii person names in search

### DIFF
--- a/src/kendzi/josm/plugin/tomb/service/OverpassService.java
+++ b/src/kendzi/josm/plugin/tomb/service/OverpassService.java
@@ -76,7 +76,7 @@ public class OverpassService {
             nameValuePairs.add(new BasicNameValuePair("data", query));
 
 
-            post.setEntity(new UrlEncodedFormEntity(nameValuePairs));
+            post.setEntity(new UrlEncodedFormEntity(nameValuePairs, "UTF-8"));
 
             HttpResponse response = client.execute(post);
             BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), encoding));


### PR DESCRIPTION
Specify encoding of keys and values that will be urlencoded and used as HTTP body for requests to Overpass API. Without specifying encoding it (on some systems only?) sends xml query in wrong charset causing names of persons with non-ASCII characters not found.

(Tested on josm 5952, custom build from josm git mirror, names such as "Ленин" cannot be searched before fix, after fix became searchable)
